### PR TITLE
Cambio la forma de validar el health

### DIFF
--- a/templates/checkWebServerUp.sh.j2
+++ b/templates/checkWebServerUp.sh.j2
@@ -1,14 +1,18 @@
 #!/bin/bash
 
+function getJsonVal () { 
+    python -c "import json,sys;sys.stdout.write(json.dumps(json.load(sys.stdin)$1))"; 
+}
+
 responseOK='"UP"'
 response=$(curl -sb -H "Accept: application/json" "{{app_health_check}}")
-isUp=$(echo $response | cut -d"," -f1 | cut -d":" -f2)
+isUp=$(echo $response | getJsonVal "['status']")
 echo "La respuesta del webserver es $isUp"
 until [[ $isUp == $responseOK ]]; do
         sleep 5;
         echo "Esperando respuesta del webserver $1"
         response=$(curl -sb -H "Accept: application/json" "{{app_health_check}}")
-        isUp=$(echo $response | cut -d"," -f1 | cut -d":" -f2)
+        isUp=$(echo $response | getJsonVal "['status']")
         echo "La respuesta del webserver es $isUp"
 done
 


### PR DESCRIPTION
Agrego una funcion de shell usando python para poder parsear el json de health del WebServer.
Antes el cut no servía en casos donde "status" no fuera el primer campo del json, ni en casos de json de 1 solo campo {"status":"UP"} ( esto hacia que isUp fuera "UP"}, siempre != a "UP" ).

Ahora solo podria fallar en casos donde en el json se repita la clave status.
Ya no es necesario que status sea el primer campo.